### PR TITLE
Remove unused include of rosbag2_cpp/typesupport_helpers.hpp

### DIFF
--- a/include/event_image_reconstruction_fibar/bag_to_frames.hpp
+++ b/include/event_image_reconstruction_fibar/bag_to_frames.hpp
@@ -26,7 +26,6 @@
 #include <rclcpp/serialized_message.hpp>
 #include <rosbag2_cpp/reader.hpp>
 #include <rosbag2_cpp/readers/sequential_reader.hpp>
-#include <rosbag2_cpp/typesupport_helpers.hpp>
 #include <rosbag2_cpp/writer.hpp>
 #include <rosbag2_cpp/writers/sequential_writer.hpp>
 #include <rosbag2_storage/serialized_bag_message.hpp>


### PR DESCRIPTION
This header file was [removed](https://github.com/ros2/rosbag2/pull/2017) in Jazzy (rosbag2 release 0.26.10). Since nothing seems to use this header file, let's remove it.

This fixes the following compile error:

    In file included from src/bag_to_frames_main.cpp:19:
    include/event_image_reconstruction_fibar/bag_to_frames.hpp:29:10:
    fatal error: rosbag2_cpp/typesupport_helpers.hpp: No such file or
    directory
       29 | #include <rosbag2_cpp/typesupport_helpers.hpp>
          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~